### PR TITLE
Minor updates to install script

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -460,7 +460,7 @@ def install_python(prefix, dir='.'):
 
         system([conda, 'install', '-n', 'wmt',
                 'numpy', 'scipy', 'setuptools', 'netcdf4', 'shapely',
-                'pyyaml', 'nose>=1.3', 'requests'])
+                'pyyaml', 'nose>=1.3', 'requests', 'ipython'])
 
         system([conda, 'update', '-n', 'wmt', '--all'])
 

--- a/scripts/install
+++ b/scripts/install
@@ -339,6 +339,7 @@ def install_csdms_stack(prefix):
     brew('csdms/tools/bocca', args=[opt_with_python])
     brew('csdms/tools/boccatools', args=[opt_with_python])
 
+    brew('pkg-config')
     brew('csdms/models/child', args=['--HEAD'])
     brew('csdms/models/hydrotrend')
     brew('csdms/models/sedflux', args=['--HEAD'])

--- a/scripts/install
+++ b/scripts/install
@@ -357,6 +357,7 @@ def install_csdms_stack(prefix):
     install_python_package_from_github(('bmi-forum', 'bmi-babel'), optdir,
                                        develop=True)
     install_python_package_from_github('pexpect/pexpect', optdir)
+    install_python_package_from_github('pexpect/ptyprocess', optdir)
 
 
 def checksum_matches(path, md5):

--- a/scripts/install
+++ b/scripts/install
@@ -420,7 +420,7 @@ def download_url(url, dest, md5=None, cache='.'):
 
 
 
-def set_build_environ(keep=['HOME', 'USER', 'TERM'], env=None):
+def set_build_environ(keep=['HOME', 'USER', 'TERM', 'SHELL'], env=None):
     import getpass
 
     for key in os.environ.keys():


### PR DESCRIPTION
These are a set of four minor updates to the `install` script that I've added in the past week while trying to build an execution server for testing the TopoFlow components.
1. Install pexpect/ptyprocess
2. Add IPython for debugging
3. Use bash as the shell for building the server
4. Install pkgconfig
