### PR TITLE
Add server_url attribute to Launcher class

### DIFF
--- a/wmtexe/cmd/script.py
+++ b/wmtexe/cmd/script.py
@@ -22,6 +22,8 @@ def main():
                         help='Unique identifier for simulation')
     parser.add_argument('--extra-args', default='',
                         help='Extra arguments for wmt-slave command')
+    parser.add_argument('--server-url', default='',
+                        help='WMT API server URL')
     parser.add_argument('--launcher', choices=_LAUNCHERS.keys(),
                         default='bash', help='Launch method')
     parser.add_argument('--run', action='store_true',
@@ -29,7 +31,8 @@ def main():
 
     args = parser.parse_args()
 
-    launcher = _LAUNCHERS[args.launcher](args.uuid)
+    launcher = _LAUNCHERS[args.launcher](args.uuid,
+                                         server_url=args.server_url)
     if args.run:
         launcher.run()
     else:

--- a/wmtexe/cmd/script.py
+++ b/wmtexe/cmd/script.py
@@ -36,5 +36,5 @@ def main():
     if args.run:
         launcher.run()
     else:
-        print(launcher.script())
+        print(launcher.script().strip())
 

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -181,7 +181,7 @@ class QsubLauncher(Launcher):
 cd $TMPDIR
 
 {slave_command}
-""".strip()
+"""
     _extra_args = ['--exec-dir=$TMPDIR']
 
     def launch_command(self, **kwds):
@@ -210,7 +210,7 @@ class BashLauncher(Launcher):
 export PATH={wmt_path}
 
 {slave_command}
-""".strip()
+"""
 
     def prepend_path(self):
         """Places the `bin` directory of executor at the front of the path."""

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -14,6 +14,8 @@ class Launcher(object):
     ----------
     sim_id : str
         A unique UUID for the job.
+    server_url : str or None, optional
+        The URL of the WMT API server from which the job was submitted.
 
     Attributes
     ----------
@@ -23,14 +25,17 @@ class Launcher(object):
         Path to launch script.
     sim_id : str
         A unique UUID for the job.
+    server_url : str or None
+        The URL of the WMT API server from which the job was submitted.
 
     """
     launch_dir = '~/.wmt'
     _script = "{slave_command}"
     _extra_args = []
 
-    def __init__(self, sim_id):
+    def __init__(self, sim_id, server_url=None):
         self.sim_id = sim_id
+        self.server_url = server_url
         self.script_path = os.path.expanduser(
             os.path.join(self.launch_dir,
                          '%s.sh' % self.sim_id))
@@ -137,6 +142,9 @@ class Launcher(object):
         wmt_slave = os.path.join(sys.prefix, 'bin', 'wmt-slave')
         command = [wmt_slave, quote(self.sim_id)] + self._extra_args
 
+        if self.server_url:
+            command += ['--server-url={}'.format(self.server_url)]
+
         if extra_args:
             if isinstance(extra_args, StringTypes):
                 extra_args = shlex.split(extra_args)
@@ -174,8 +182,7 @@ cd $TMPDIR
 
 {slave_command}
 """.strip()
-    _extra_args = ['--exec-dir=$TMPDIR',
-                   '--server-url=https://csdms.colorado.edu/wmt/api-testing']
+    _extra_args = ['--exec-dir=$TMPDIR']
 
     def launch_command(self, **kwds):
         """Path to launch script.
@@ -204,7 +211,6 @@ export PATH={wmt_path}
 
 {slave_command}
 """.strip()
-    _extra_args = ['--server-url=https://csdms.colorado.edu/wmt/api-testing']
 
     def prepend_path(self):
         """Places the `bin` directory of executor at the front of the path."""

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -181,7 +181,7 @@ class QsubLauncher(Launcher):
 cd $TMPDIR
 
 {slave_command}
-"""
+""".lstrip()
     _extra_args = ['--exec-dir=$TMPDIR']
 
     def launch_command(self, **kwds):
@@ -210,7 +210,7 @@ class BashLauncher(Launcher):
 export PATH={wmt_path}
 
 {slave_command}
-"""
+""".lstrip()
 
     def prepend_path(self):
         """Places the `bin` directory of executor at the front of the path."""


### PR DESCRIPTION
When submitting a job to an executor, a WMT API server can now include its URL. This URL is passed through the Launcher class to the `wmt-slave` command, which fixes #7.