### PR TITLE
Make an sbatch launcher class

### DIFF
--- a/wmtexe/cmd/script.py
+++ b/wmtexe/cmd/script.py
@@ -4,12 +4,13 @@ from __future__ import print_function
 import sys
 import os
 
-from ..launcher import BashLauncher, QsubLauncher
+from ..launcher import BashLauncher, QsubLauncher, SbatchLauncher
 
 
 _LAUNCHERS = {
     'bash': BashLauncher,
     'qsub': QsubLauncher,
+    'sbatch': SbatchLauncher,
 }
 
 

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -206,8 +206,9 @@ class SbatchLauncher(Launcher):
     """WMT job launcher for a SLURM scheduler."""
     _script = """
 #!/usr/bin/env bash
-
-module load slurm/blanca
+#SBATCH --qos=blanca-csdms
+#SBATCH --job-name=wmt
+#SBATCH --output=wmt-%j.out
 
 {slave_command}
 """.lstrip()
@@ -226,11 +227,18 @@ module load slurm/blanca
             The launch command to execute.
 
         """
-        return ['sbatch',
-                '--qos', 'blanca-csdms',
-                '--workdir', self.launch_dir,
-                '--job-name', 'wmt-{}'.format(self.sim_id),
-                self.script_path]
+        return 'module load slurm/blanca && sbatch {}'.format(self.script_path)
+
+    def launch(self, **kwds):
+        """Launch job with launch command.
+
+        Parameters
+        ----------
+        **kwds
+            Arbitrary keyword arguments.
+
+        """
+        subprocess.check_output(self.launch_command(**kwds), shell=True)
 
 
 class BashLauncher(Launcher):

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -208,7 +208,6 @@ class SbatchLauncher(Launcher):
 #!/usr/bin/env bash
 #SBATCH --qos=blanca-csdms
 #SBATCH --job-name=wmt
-#SBATCH --output=wmt-%j.out
 
 export MPLBACKEND=Agg
 {slave_command}
@@ -217,7 +216,7 @@ export MPLBACKEND=Agg
 #!/usr/bin/env bash
 
 module load slurm/blanca
-sbatch {script_path}
+sbatch --output={output_file} {script_path}
 """.lstrip()
 
     def __init__(self, *args, **kwds):
@@ -233,7 +232,11 @@ sbatch {script_path}
         os.chmod(self.run_script_path, stat.S_IXUSR|stat.S_IWUSR|stat.S_IRUSR)
 
     def run_script(self, **kwds):
-        return self._run_script.format(script_path=self.script_path)
+        output_file = os.path.expanduser(
+            os.path.join(self.launch_dir,
+                         '%s.out' % self.sim_id))
+        return self._run_script.format(output_file=output_file,
+                                       script_path=self.script_path)
 
     def launch_command(self, **kwds):
         return self.run_script_path

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -242,7 +242,7 @@ sbatch --output={output_file} {script_path}
         return self.run_script_path
 
     def launch(self, **kwds):
-        os.system(self.launch_command())
+        subprocess.check_output(self.launch_command(**kwds))
 
 
 class BashLauncher(Launcher):

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -212,33 +212,33 @@ class SbatchLauncher(Launcher):
 
 {slave_command}
 """.lstrip()
+    _run_script = """
+#!/usr/bin/env bash
+
+module load slurm/blanca
+sbatch {script_path}
+""".lstrip()
+
+    def __init__(self, *args, **kwds):
+        Launcher.__init__(self, *args, **kwds)
+        self.run_script_path = os.path.expanduser(
+            os.path.join(self.launch_dir,
+                         '%s.run.sh' % self.sim_id))
+
+    def before_launch(self, **kwds):
+        Launcher.before_launch(self, **kwds)
+        with open(self.run_script_path, 'w') as f:
+            f.write(self.run_script(**kwds))
+        os.chmod(self.run_script_path, stat.S_IXUSR|stat.S_IWUSR|stat.S_IRUSR)
+
+    def run_script(self, **kwds):
+        return self._run_script.format(script_path=self.script_path)
 
     def launch_command(self, **kwds):
-        """Path to launch script.
-
-        Parameters
-        ----------
-        **kwds
-            Arbitrary keyword arguments.
-
-        Returns
-        -------
-        str
-            The launch command to execute.
-
-        """
-        return 'module load slurm/blanca && sbatch {}'.format(self.script_path)
+        return self.run_script_path
 
     def launch(self, **kwds):
-        """Launch job with launch command.
-
-        Parameters
-        ----------
-        **kwds
-            Arbitrary keyword arguments.
-
-        """
-        subprocess.check_output(self.launch_command(**kwds), shell=True)
+        os.system(self.launch_command())
 
 
 class BashLauncher(Launcher):

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -210,6 +210,7 @@ class SbatchLauncher(Launcher):
 #SBATCH --job-name=wmt
 #SBATCH --output=wmt-%j.out
 
+export MPLBACKEND=Agg
 {slave_command}
 """.lstrip()
     _run_script = """

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -107,7 +107,7 @@ class Launcher(object):
         subprocess.check_output(self.launch_command(**kwds), env={})
 
     def launch_command(self, **kwds):
-        """Path to launch script.
+        """The command that runs a job.
 
         Parameters
         ----------
@@ -203,7 +203,29 @@ cd $TMPDIR
 
 
 class SbatchLauncher(Launcher):
-    """WMT job launcher for a SLURM scheduler."""
+    """WMT job launcher for a Slurm scheduler.
+
+    Parameters
+    ----------
+    sim_id : str
+        A unique UUID for the job.
+    server_url : str or None, optional
+        The URL of the WMT API server from which the job was submitted.
+
+    Attributes
+    ----------
+    launch_dir : str
+        The working directory from which the job is started.
+    script_path : str
+        Path to launch script.
+    run_script_path : str
+        Path to run script, which submits launch script to scheduler.
+    sim_id : str
+        A unique UUID for the job.
+    server_url : str or None
+        The URL of the WMT API server from which the job was submitted.
+
+    """
     _script = """
 #!/usr/bin/env bash
 #SBATCH --qos=blanca-csdms
@@ -226,12 +248,33 @@ sbatch --output={output_file} {script_path}
                          '%s.run.sh' % self.sim_id))
 
     def before_launch(self, **kwds):
+        """Perform actions before launching job.
+
+        Parameters
+        ----------
+        **kwds
+            Arbitrary keyword arguments.
+
+        """
         Launcher.before_launch(self, **kwds)
         with open(self.run_script_path, 'w') as f:
             f.write(self.run_script(**kwds))
         os.chmod(self.run_script_path, stat.S_IXUSR|stat.S_IWUSR|stat.S_IRUSR)
 
     def run_script(self, **kwds):
+        """Generate the run script that submits job to scheduler.
+
+        Parameters
+        ----------
+        *kwds
+            Arbitrary keyword arguments.
+
+        Returns
+        -------
+        str
+            The run script to be written to a file.
+
+        """
         output_file = os.path.expanduser(
             os.path.join(self.launch_dir,
                          '%s.out' % self.sim_id))
@@ -239,9 +282,33 @@ sbatch --output={output_file} {script_path}
                                        script_path=self.script_path)
 
     def launch_command(self, **kwds):
+        """The command that runs a job.
+
+        Parameters
+        ----------
+        **kwds
+            Arbitrary keyword arguments.
+
+        Returns
+        -------
+        str
+            The launch command to execute.
+
+        """
         return self.run_script_path
 
     def launch(self, **kwds):
+        """Launch job with launch command.
+
+        Note that we override Launcher.launch because we want to
+        inherit the environment from the current process.
+
+        Parameters
+        ----------
+        **kwds
+            Arbitrary keyword arguments.
+
+        """
         subprocess.check_output(self.launch_command(**kwds))
 
 

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -202,6 +202,37 @@ cd $TMPDIR
                 self.script_path]
 
 
+class SbatchLauncher(Launcher):
+    """WMT job launcher for a SLURM scheduler."""
+    _script = """
+#!/usr/bin/env bash
+
+module load slurm/blanca
+
+{slave_command}
+""".lstrip()
+
+    def launch_command(self, **kwds):
+        """Path to launch script.
+
+        Parameters
+        ----------
+        **kwds
+            Arbitrary keyword arguments.
+
+        Returns
+        -------
+        str
+            The launch command to execute.
+
+        """
+        return ['sbatch',
+                '--qos', 'blanca-csdms',
+                '--workdir', self.launch_dir,
+                '--job-name', 'wmt-{}'.format(self.sim_id),
+                self.script_path]
+
+
 class BashLauncher(Launcher):
     """WMT job launcher for a bash environment."""
     _script = """

--- a/wmtexe/task.py
+++ b/wmtexe/task.py
@@ -9,6 +9,7 @@ import json
 import threading
 import logging
 import requests
+import socket
 
 from cmt.component.model import Model
 from cmt.framework.services import register_component_classes
@@ -797,16 +798,17 @@ class RunComponentCoupled(RunTask):
         with open(os.path.join(self.sim_dir, 'model.yaml'), 'r') as fp:
             model = yaml.load(fp.read())
 
-        with open('.info.yaml', 'w') as fp:
+        with open('info.yaml', 'w') as fp:
             info = {
                 'start_time': datetime.now().isoformat(),
                 'server': self.server,
+                'host': socket.gethostname(),
                 'id': self.id,
                 'prefix': self.sim_dir,
                 'stdout': 'stdout',
                 'driver': model['driver'],
             }
-            yaml.dump(info, stream=fp, default_flow_style=True)
+            yaml.dump(info, stream=fp, default_flow_style=False)
 
         # driver = os.path.join(self.sim_dir, model['driver'])
         status_file = os.path.abspath('stdout')


### PR DESCRIPTION
The new CSDMS cluster, *blanca*, uses [Slurm](https://slurm.schedmd.com/overview.html) as a job scheduler instead of Torque, which implies a new Launcher class.