### PR TITLE
Use site configuration file to set launch and execution directories

### DIFF
--- a/wmtexe/cmd/script.py
+++ b/wmtexe/cmd/script.py
@@ -28,7 +28,7 @@ def main():
                         help='WMT API server URL')
     parser.add_argument('--launcher', choices=_LAUNCHERS.keys(),
                         default='bash', help='Launch method')
-    parser.add_argument('--config', default='wmt.cfg',
+    parser.add_argument('--config', default='',
                         help='WMT site configuration file')
     parser.add_argument('--run', action='store_true',
                         help='Launch simulation')

--- a/wmtexe/cmd/script.py
+++ b/wmtexe/cmd/script.py
@@ -39,10 +39,15 @@ def main():
     launch_dir = config.get('paths', 'launch_dir')
     exec_dir = config.get('paths', 'exec_dir')
 
+    extra_args = []
+    extra_args.append('--exec-dir={}'.format(exec_dir))
+    if args.extra_args:
+        extra_args.append(args.extra_args)
+
     launcher = _LAUNCHERS[args.launcher](args.uuid,
                                          server_url=args.server_url,
                                          launch_dir=launch_dir,
-                                         exec_dir=exec_dir)
+                                         extra_args=extra_args)
     if args.run:
         launcher.run()
     else:

--- a/wmtexe/cmd/script.py
+++ b/wmtexe/cmd/script.py
@@ -40,7 +40,7 @@ def main():
     exec_dir = config.get('paths', 'exec_dir')
 
     extra_args = []
-    extra_args.append('--exec-dir={}'.format(exec_dir))
+    extra_args.append('--exec-dir={}'.format(os.path.expandvars(exec_dir)))
     if args.extra_args:
         extra_args.append(args.extra_args)
 
@@ -48,6 +48,7 @@ def main():
                                          server_url=args.server_url,
                                          launch_dir=launch_dir,
                                          extra_args=extra_args)
+
     if args.run:
         launcher.run()
     else:

--- a/wmtexe/cmd/script.py
+++ b/wmtexe/cmd/script.py
@@ -5,6 +5,7 @@ import sys
 import os
 
 from ..launcher import BashLauncher, QsubLauncher, SbatchLauncher
+from ..config import load_configuration
 
 
 _LAUNCHERS = {
@@ -27,13 +28,21 @@ def main():
                         help='WMT API server URL')
     parser.add_argument('--launcher', choices=_LAUNCHERS.keys(),
                         default='bash', help='Launch method')
+    parser.add_argument('--config', default='wmt.cfg',
+                        help='WMT site configuration file')
     parser.add_argument('--run', action='store_true',
                         help='Launch simulation')
 
     args = parser.parse_args()
 
+    config = load_configuration(args.config)
+    launch_dir = config.get('paths', 'launch_dir')
+    exec_dir = config.get('paths', 'exec_dir')
+
     launcher = _LAUNCHERS[args.launcher](args.uuid,
-                                         server_url=args.server_url)
+                                         server_url=args.server_url,
+                                         launch_dir=launch_dir,
+                                         exec_dir=exec_dir)
     if args.run:
         launcher.run()
     else:

--- a/wmtexe/commands/configure.py
+++ b/wmtexe/commands/configure.py
@@ -23,6 +23,7 @@ class Configure(Command):
         ('with-python=', None, 'path to python command'),
         ('wmt-prefix=', None, 'prefix of WMT installation'),
         ('components-prefix=', None, 'prefix of components installation'),
+        ('exec-dir=', None, 'location of user execution directory'),
         ('clobber', None, 'clobber existing configuration'),
     ]
 
@@ -34,6 +35,7 @@ class Configure(Command):
         self.with_cca_spec_babel_config = None
         self.wmt_prefix = None
         self.components_prefix = None
+        self.exec_dir = None
         self.clobber = False
 
     def finalize_options(self):
@@ -53,6 +55,7 @@ class Configure(Command):
                    self.with_cca_spec_babel_config)
         config.set('paths', 'wmt_prefix', self.wmt_prefix)
         config.set('paths', 'components_prefix', self.components_prefix)
+        config.set('paths', 'exec_dir', self.exec_dir)
 
         if path.isfile('wmt.cfg') and not self.clobber:
             print 'wmt.cfg: file exists (use --clobber to overwrite)'

--- a/wmtexe/commands/configure.py
+++ b/wmtexe/commands/configure.py
@@ -23,7 +23,8 @@ class Configure(Command):
         ('with-python=', None, 'path to python command'),
         ('wmt-prefix=', None, 'prefix of WMT installation'),
         ('components-prefix=', None, 'prefix of components installation'),
-        ('exec-dir=', None, 'location of user execution directory'),
+        ('launch-dir=', None, 'directory from which job is started'),
+        ('exec-dir=', None, 'directory where job is run'),
         ('clobber', None, 'clobber existing configuration'),
     ]
 
@@ -35,6 +36,7 @@ class Configure(Command):
         self.with_cca_spec_babel_config = None
         self.wmt_prefix = None
         self.components_prefix = None
+        self.launch_dir = None
         self.exec_dir = None
         self.clobber = False
 
@@ -55,6 +57,7 @@ class Configure(Command):
                    self.with_cca_spec_babel_config)
         config.set('paths', 'wmt_prefix', self.wmt_prefix)
         config.set('paths', 'components_prefix', self.components_prefix)
+        config.set('paths', 'launch_dir', self.launch_dir)
         config.set('paths', 'exec_dir', self.exec_dir)
 
         if path.isfile('wmt.cfg') and not self.clobber:

--- a/wmtexe/config.py
+++ b/wmtexe/config.py
@@ -66,6 +66,19 @@ class SiteConfiguration(object):
         """
         return self._config.items(section)
 
+    def get(self, section, option):
+        """Get a configuration value.
+
+        Parameters
+        ----------
+        section : str
+            Name of section in configuration.
+        option : str
+            Name of configuration option.
+
+        """
+        return self._config.get(section, option)
+
     def set(self, section, option, value):
         """Set a configuration value.
 

--- a/wmtexe/config.py
+++ b/wmtexe/config.py
@@ -6,10 +6,6 @@ import sys
 import types
 
 
-INSTALL_ETC = os.path.join(sys.exec_prefix, 'etc')
-USER_CONFIG_PATH = os.path.expanduser('~/.wmt')
-
-
 def _find_executable(executable, **kwds):
     from distutils.spawn import find_executable
 
@@ -27,8 +23,8 @@ _DEFAULTS = [
         ('python', _find_executable('python')),
         ('wmt_prefix', '/usr/local'),
         ('components_prefix', '/usr/local'),
-        ('exec_dir', USER_CONFIG_PATH),
-        ('launch_dir', USER_CONFIG_PATH),
+        ('exec_dir', '~/.wmt'),
+        ('launch_dir', '~/.wmt'),
     ]),
     ('launcher', [
         ('name', 'bash-launcher'),
@@ -141,6 +137,10 @@ class SiteConfiguration(object):
         output.close()
 
         return contents.strip()
+
+
+INSTALL_ETC = os.path.join(sys.exec_prefix, 'etc')
+USER_CONFIG_PATH = os.path.expanduser('~/.wmt')
 
 
 def load_configuration(filenames=None):

--- a/wmtexe/config.py
+++ b/wmtexe/config.py
@@ -28,6 +28,7 @@ _DEFAULTS = [
         ('wmt_prefix', '/usr/local'),
         ('components_prefix', '/usr/local'),
         ('exec_dir', USER_CONFIG_PATH),
+        ('launch_dir', USER_CONFIG_PATH),
     ]),
     ('launcher', [
         ('name', 'bash-launcher'),

--- a/wmtexe/config.py
+++ b/wmtexe/config.py
@@ -6,6 +6,10 @@ import sys
 import types
 
 
+INSTALL_ETC = os.path.join(sys.exec_prefix, 'etc')
+USER_CONFIG_PATH = os.path.expanduser('~/.wmt')
+
+
 def _find_executable(executable, **kwds):
     from distutils.spawn import find_executable
 
@@ -23,6 +27,7 @@ _DEFAULTS = [
         ('python', _find_executable('python')),
         ('wmt_prefix', '/usr/local'),
         ('components_prefix', '/usr/local'),
+        ('exec_dir', USER_CONFIG_PATH),
     ]),
     ('launcher', [
         ('name', 'bash-launcher'),
@@ -122,11 +127,6 @@ class SiteConfiguration(object):
         output.close()
 
         return contents.strip()
-
-
-DEFAULT = SiteConfiguration()
-INSTALL_ETC = os.path.join(sys.exec_prefix, 'etc')
-USER_CONFIG_PATH = os.path.expanduser('~/.wmt')
 
 
 def load_configuration(filenames=None):

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -39,10 +39,9 @@ class Launcher(object):
                  extra_args=[]):
         self.sim_id = sim_id
         self.server_url = server_url
-        self.launch_dir = launch_dir
-        self.script_path = os.path.expanduser(
-            os.path.join(self.launch_dir,
-                         '%s.sh' % self.sim_id))
+        self.launch_dir = os.path.expandvars(os.path.expanduser(launch_dir))
+        self.script_path = os.path.join(self.launch_dir,
+                                        '%s.sh' % self.sim_id)
         self._extra_args = extra_args
 
     def before_launch(self, **kwds):

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -182,7 +182,6 @@ cd $TMPDIR
 
 {slave_command}
 """.lstrip()
-    _extra_args = ['--exec-dir=$TMPDIR']
 
     def launch_command(self, **kwds):
         """Path to launch script.

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -18,8 +18,8 @@ class Launcher(object):
         The URL of the WMT API server from which the job was submitted.
     launch_dir : str, optional
         The working directory from which the job is started.
-    exec_dir : str, optional
-        The directory where the job is run.
+    extra_args : list, optional
+        Extra arguments to be passed to the wmt-slave command.
 
     Attributes
     ----------
@@ -34,17 +34,16 @@ class Launcher(object):
 
     """
     _script = "{slave_command}"
-    _extra_args = []
 
     def __init__(self, sim_id, server_url=None, launch_dir='~/.wmt',
-                 exec_dir='~/.wmt'):
+                 extra_args=[]):
         self.sim_id = sim_id
         self.server_url = server_url
         self.launch_dir = launch_dir
         self.script_path = os.path.expanduser(
             os.path.join(self.launch_dir,
                          '%s.sh' % self.sim_id))
-        self._extra_args.append('--exec-dir={}'.format(exec_dir))
+        self._extra_args = extra_args
 
     def before_launch(self, **kwds):
         """Perform actions before launching job.
@@ -218,8 +217,8 @@ class SbatchLauncher(Launcher):
         The URL of the WMT API server from which the job was submitted.
     launch_dir : str, optional
         The working directory from which the job is started.
-    exec_dir : str, optional
-        The directory where the job is run.
+    extra_args : list, optional
+        Extra arguments to be passed to the wmt-slave command.
 
     Attributes
     ----------

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -16,6 +16,10 @@ class Launcher(object):
         A unique UUID for the job.
     server_url : str or None, optional
         The URL of the WMT API server from which the job was submitted.
+    launch_dir : str, optional
+        The working directory from which the job is started.
+    exec_dir : str, optional
+        The directory where the job is run.
 
     Attributes
     ----------
@@ -29,16 +33,18 @@ class Launcher(object):
         The URL of the WMT API server from which the job was submitted.
 
     """
-    launch_dir = '~/.wmt'
     _script = "{slave_command}"
     _extra_args = []
 
-    def __init__(self, sim_id, server_url=None):
+    def __init__(self, sim_id, server_url=None, launch_dir='~/.wmt',
+                 exec_dir='~/.wmt'):
         self.sim_id = sim_id
         self.server_url = server_url
+        self.launch_dir = launch_dir
         self.script_path = os.path.expanduser(
             os.path.join(self.launch_dir,
                          '%s.sh' % self.sim_id))
+        self._extra_args.append('--exec-dir={}'.format(exec_dir))
 
     def before_launch(self, **kwds):
         """Perform actions before launching job.
@@ -210,6 +216,10 @@ class SbatchLauncher(Launcher):
         A unique UUID for the job.
     server_url : str or None, optional
         The URL of the WMT API server from which the job was submitted.
+    launch_dir : str, optional
+        The working directory from which the job is started.
+    exec_dir : str, optional
+        The directory where the job is run.
 
     Attributes
     ----------

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -53,6 +53,11 @@ class Launcher(object):
             Arbitrary keyword arguments.
 
         """
+        try:
+            os.makedirs(self.launch_dir)
+        except OSError:
+            if not os.path.isdir(self.launch_dir):
+                raise
         with open(self.script_path, 'w') as f:
             f.write(self.script(**kwds))
         os.chmod(self.script_path, stat.S_IXUSR|stat.S_IWUSR|stat.S_IRUSR)

--- a/wmtexe/reporter.py
+++ b/wmtexe/reporter.py
@@ -280,13 +280,16 @@ class WmtTaskReporter(object):
         A unique UUID for a job.
     server : str
         URL of API server.
+    exe_dir : str, optional
+        Run directory (default is '~/.wmt').
 
     """
-    def __init__(self, id, server):
+    def __init__(self, id, server, exe_dir='~/.wmt'):
         self._id = id
         self._server = server
         self._curl = os.environ.get('CURL', 'curl')
-        log_file = os.path.expanduser('~/.wmt/%s.log' % self.id)
+        self._exe_dir = os.path.expandvars(os.path.expanduser(exe_dir))
+        log_file = os.path.join(self._exe_dir, '%s.log' % self.id)
         logging.basicConfig(filename=log_file, filemode='w',
                             level=logging.DEBUG)
 

--- a/wmtexe/task.py
+++ b/wmtexe/task.py
@@ -92,7 +92,7 @@ def create_user_execution_dir(run_id, prefix='~/.wmt'):
     run_id : str
         A unique UUID for a job.
     prefix : str, optional
-        Path to the launch directory (default is "~/.wmt").
+        Path to the run directory (default is "~/.wmt").
 
     Returns
     -------
@@ -615,9 +615,9 @@ class RunTask(WmtTaskReporter):
 
     """
     def __init__(self, run_id, server, exe_env=None, exe_dir='~/.wmt'):
-        super(RunTask, self).__init__(run_id, server)
+        super(RunTask, self).__init__(run_id, server, exe_dir=exe_dir)
 
-        self._wmt_dir = os.path.expanduser(exe_dir)
+        self._wmt_dir = os.path.expandvars(os.path.expanduser(exe_dir))
         self._sim_dir = create_user_execution_dir(run_id,
                                                   prefix=self._wmt_dir)
         self._env = exe_env


### PR DESCRIPTION
When the WMT backend was designed, the site configuration file was used to set paths to various things. It fell out of use as the backend was further developed and streamlined. I'm rehabilitating it here to allow an administrator to set the locations of the launch and execution directories on the execution server.

This solves the problem raised in #14.