### PR TITLE
Translate to Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,4 +64,10 @@ setup(
         'configure': Configure,
         'install': Install,
     },
+
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2.7',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ setup(
 
     packages=['wmtexe', 'wmtexe.cmd', 'wmtexe.cmi'],
 
+    install_requires=['requests'],
+
     entry_points={
         'console_scripts': [
             'wmt-slave=wmtexe.cmd.slave:main',

--- a/wmtexe/audit.py
+++ b/wmtexe/audit.py
@@ -70,9 +70,9 @@ def result_message(assertion, checking):
 
     """
     if assertion:
-        return ' '.join([formatting.green('\u2713'), checking, 'yes'])
+        return ' '.join([formatting.green('\\u2713'), checking, 'yes'])
     else:
-        return ' '.join([formatting.red('\u2717'), checking, 'no'])
+        return ' '.join([formatting.red('\\u2717'), checking, 'no'])
 
 
 def check_is_executable(program):

--- a/wmtexe/audit.py
+++ b/wmtexe/audit.py
@@ -70,9 +70,9 @@ def result_message(assertion, checking):
 
     """
     if assertion:
-        return ' '.join([formatting.green(u'\u2713'), checking, 'yes'])
+        return ' '.join([formatting.green('\u2713'), checking, 'yes'])
     else:
-        return ' '.join([formatting.red(u'\u2717'), checking, 'no'])
+        return ' '.join([formatting.red('\u2717'), checking, 'no'])
 
 
 def check_is_executable(program):

--- a/wmtexe/cmd/activate.py
+++ b/wmtexe/cmd/activate.py
@@ -90,7 +90,7 @@ def environ_update(env):
 
 def environ_as_bash_commands(env):
     commands = []
-    names = env.keys()
+    names = list(env.keys())
     names.sort()
     for name in names:
         if env[name] is None:

--- a/wmtexe/cmd/activate.py
+++ b/wmtexe/cmd/activate.py
@@ -1,6 +1,7 @@
 """Activate and deactivate a wmt-exe environment."""
 
 from __future__ import print_function
+
 import sys
 import os
 

--- a/wmtexe/cmd/audit.py
+++ b/wmtexe/cmd/audit.py
@@ -1,5 +1,7 @@
 """Audit the setup for a WMT simulation."""
 
+from __future__ import print_function
+
 from .. import formatting
 from ..env import WmtEnvironment
 from ..audit import audit
@@ -16,9 +18,9 @@ def main():
 
     env = WmtEnvironment.from_config(args.file)
 
-    print formatting.red('Auditing the following environment')
-    print str(env)
+    print(formatting.red('Auditing the following environment'))
+    print(str(env))
 
-    print '\n\n'
-    print formatting.red('This is what I found...')
-    print audit(env.env)
+    print('\n\n')
+    print(formatting.red('This is what I found...'))
+    print(audit(env.env))

--- a/wmtexe/cmd/exe.py
+++ b/wmtexe/cmd/exe.py
@@ -1,5 +1,7 @@
 """Execute a WMT simulation."""
 
+from __future__ import print_function
+
 import os
 import sys
 import subprocess
@@ -51,7 +53,7 @@ def main():
                 # pipe = subprocess.Popen(cmd, env=env.env, stdout=stdout,
                 pipe = subprocess.Popen(cmd, env=env, stdout=stdout,
                                         stderr=stderr)
-        print pipe.pid
+        print(pipe.pid)
     else:
         # subprocess.call(cmd, env=env.env)
         subprocess.call(cmd, env=env)

--- a/wmtexe/cmd/get.py
+++ b/wmtexe/cmd/get.py
@@ -3,6 +3,9 @@
 Connect to a WMT server and download a staged simulation using a universal
 unique identifier.
 """
+
+from __future__ import print_function
+
 import os
 import sys
 import argparse
@@ -17,7 +20,7 @@ def download_or_exit(url, id, dest):
         tarball = download_run_tarball(url, id,
                                        dest_dir=dest)
     except DownloadError as error:
-        print '==> Error: %s' % error
+        print('==> Error: %s' % error)
         sys.exit(1)
 
     return os.path.normpath(tarball)
@@ -28,7 +31,7 @@ def unpack_or_exit(name, dest):
         with tarfile.open(name, 'r') as tar:
             tar.extractall(path=dest)
     except tarfile.TarError as error:
-        print '==> Error: %s' % error
+        print('==> Error: %s' % error)
         sys.exit(1)
     try:
         base = name[:- len('.tar.gz')]
@@ -74,24 +77,24 @@ def main():
     env = WmtEnvironment.from_config(args.config)
 
     if args.show_env:
-        print str(env)
+        print(str(env))
         return
 
     if args.verbose:
-        print '==> connecting %s' % args.url
-        print '==> downloading %s' % args.id
+        print('==> connecting %s' % args.url)
+        print('==> downloading %s' % args.id)
 
     tarball = download_or_exit(args.url, args.id, args.dest)
 
     if args.unpack == 'yes':
         if args.verbose:
-            print '==> unpacking %s' % tarball
+            print('==> unpacking %s' % tarball)
 
         unpack_or_exit(tarball, args.dest)
 
         if args.clean:
-            print '==> removing %s' % tarball
+            print('==> removing %s' % tarball)
             os.remove(tarball)
 
     if args.verbose:
-        print '==> success'
+        print('==> success')

--- a/wmtexe/cmd/get.py
+++ b/wmtexe/cmd/get.py
@@ -36,7 +36,7 @@ def unpack_or_exit(name, dest):
     try:
         base = name[:- len('.tar.gz')]
         for r, _, _ in os.walk(base):
-            os.chmod(r, 0777 - get_umask())
+            os.chmod(r, 0o777 - get_umask())
     except OSError:
         raise
 

--- a/wmtexe/cmd/info.py
+++ b/wmtexe/cmd/info.py
@@ -6,8 +6,8 @@ import sys
 
 
 def dict_to_ini(d, section):
-    from ConfigParser import ConfigParser
-    from StringIO import StringIO
+    from configparser import ConfigParser
+    from io import StringIO
 
     config = ConfigParser()
     config.add_section(section)

--- a/wmtexe/cmd/info.py
+++ b/wmtexe/cmd/info.py
@@ -1,5 +1,7 @@
 """Get information about the current wmt-exe environment."""
 
+from __future__ import print_function
+
 import sys
 
 
@@ -46,4 +48,4 @@ def main():
         'directory': args.directory,
     }
 
-    print dict_to_ini(host_info, args.host)
+    print(dict_to_ini(host_info, args.host))

--- a/wmtexe/cmd/info.py
+++ b/wmtexe/cmd/info.py
@@ -12,7 +12,7 @@ def dict_to_ini(d, section):
     config = ConfigParser()
     config.add_section(section)
 
-    for (key, value) in d.items():
+    for (key, value) in list(d.items()):
         config.set(section, key, value)
 
     output = StringIO()

--- a/wmtexe/cmd/quickstart.py
+++ b/wmtexe/cmd/quickstart.py
@@ -30,7 +30,7 @@ class Prompter(object):
     def _get_non_empty_input(self, text, default=None):
         if self._interactive:
             while True:
-                val = input(self.render_prompt(text, default=default))
+                val = eval(input(self.render_prompt(text, default=default)))
                 if default and not val:
                     val = default
                 break
@@ -42,7 +42,7 @@ class Prompter(object):
     def list(self, key, text, default=None):
         vals = []
         while True:
-            val = input(self.render_prompt(text, default=default))
+            val = eval(input(self.render_prompt(text, default=default)))
             if default and not val:
                 val = default
             if len(val.strip()) > 0:

--- a/wmtexe/cmd/quickstart.py
+++ b/wmtexe/cmd/quickstart.py
@@ -66,7 +66,7 @@ def dict_to_ini(d, section):
     config = ConfigParser()
     config.add_section(section)
 
-    for (key, value) in d.items():
+    for (key, value) in list(d.items()):
         config.set(section, key, value)
 
     output = StringIO()

--- a/wmtexe/cmd/quickstart.py
+++ b/wmtexe/cmd/quickstart.py
@@ -60,8 +60,8 @@ class Prompter(object):
 
 
 def dict_to_ini(d, section):
-    from ConfigParser import ConfigParser
-    from StringIO import StringIO
+    from configparser import ConfigParser
+    from io import StringIO
 
     config = ConfigParser()
     config.add_section(section)

--- a/wmtexe/cmd/quickstart.py
+++ b/wmtexe/cmd/quickstart.py
@@ -30,7 +30,7 @@ class Prompter(object):
     def _get_non_empty_input(self, text, default=None):
         if self._interactive:
             while True:
-                val = raw_input(self.render_prompt(text, default=default))
+                val = input(self.render_prompt(text, default=default))
                 if default and not val:
                     val = default
                 break
@@ -42,7 +42,7 @@ class Prompter(object):
     def list(self, key, text, default=None):
         vals = []
         while True:
-            val = raw_input(self.render_prompt(text, default=default))
+            val = input(self.render_prompt(text, default=default))
             if default and not val:
                 val = default
             if len(val.strip()) > 0:

--- a/wmtexe/cmd/quickstart.py
+++ b/wmtexe/cmd/quickstart.py
@@ -1,5 +1,7 @@
 """Configure a wmt-exe environment from the command prompt."""
 
+from __future__ import print_function
+
 import os
 from distutils.spawn import find_executable
 
@@ -141,4 +143,4 @@ def main():
         qsub_launcher = prompt_for_qsub_launcher(**kwds)
         sections.append(dict_to_ini(qsub_launcher, 'qsub-launcher'))
 
-    print (os.linesep * 2).join(sections)
+    print((os.linesep * 2).join(sections))

--- a/wmtexe/cmd/run.py
+++ b/wmtexe/cmd/run.py
@@ -1,5 +1,7 @@
 """Run a simulation from an existing WMT configuration."""
 
+from __future__ import print_function
+
 import os
 import argparse
 
@@ -49,7 +51,7 @@ def main():
     env = WmtEnvironment.from_config(args.config)
 
     if args.show_env:
-        print str(env)
+        print(str(env))
         return
 
     run(args.path)

--- a/wmtexe/cmd/script.py
+++ b/wmtexe/cmd/script.py
@@ -27,7 +27,7 @@ def main():
                         help='Extra arguments for wmt-slave command')
     parser.add_argument('--server-url', default='',
                         help='WMT API server URL')
-    parser.add_argument('--launcher', choices=_LAUNCHERS.keys(),
+    parser.add_argument('--launcher', choices=list(_LAUNCHERS.keys()),
                         default='bash', help='Launch method')
     parser.add_argument('--config', default='',
                         help='WMT site configuration file')

--- a/wmtexe/cmd/script.py
+++ b/wmtexe/cmd/script.py
@@ -1,6 +1,7 @@
 """Launch a WMT simulation using `bash` or `qsub`."""
 
 from __future__ import print_function
+
 import sys
 import os
 

--- a/wmtexe/cmd/slave.py
+++ b/wmtexe/cmd/slave.py
@@ -12,9 +12,9 @@ from ..env import WmtEnvironment
 
 class EnsureHttps(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
-        import urlparse
-        o = urlparse.urlsplit(values)
-        url = urlparse.urlunsplit(('https', o.netloc, o.path, '', ''))
+        import urllib.parse
+        o = urllib.parse.urlsplit(values)
+        url = urllib.parse.urlunsplit(('https', o.netloc, o.path, '', ''))
         setattr(namespace, self.dest, url)
 
 

--- a/wmtexe/cmd/slave.py
+++ b/wmtexe/cmd/slave.py
@@ -1,5 +1,7 @@
 """Initiate and monitor a task slave for a WMT simulation."""
 
+from __future__ import print_function
+
 import os
 import sys
 import argparse
@@ -43,7 +45,7 @@ def main():
     #     ['/home/csdms/wmt/topoflow.1/conda/bin', env['PATH']])
 
     if args.show_env:
-        print str(env)
+        print(str(env))
         return
 
     # slave = Slave(args.server_url, env=env.env)
@@ -56,8 +58,8 @@ def main():
     #    print error
     except Exception as error:
         slave.report_error(args.id, traceback.format_exc())
-        print traceback.format_exc()
+        print(traceback.format_exc())
     else:
         slave.report_success(
             args.id, 'simulation is complete and available for pickup')
-        print 'success'
+        print('success')

--- a/wmtexe/cmi/api.py
+++ b/wmtexe/cmi/api.py
@@ -1,7 +1,8 @@
 #! /usr/bin/env python
+from __future__ import print_function
+
 import os
 import types
-
 import yaml
 
 from .utils import cd, check_output, system
@@ -16,7 +17,7 @@ _VALID_KEYS = _REQUIRED_KEYS | _OPTIONAL_KEYS
 
 def is_valid_api(api):
     if not isinstance(api, dict):
-        print 'not a dict'
+        print('not a dict')
         return False
 
     found_keys = set(api.keys())
@@ -25,7 +26,7 @@ def is_valid_api(api):
         return False
 
     if not found_keys.issubset(_VALID_KEYS):
-        print 'unknown key'
+        print('unknown key')
         return False
 
     return True

--- a/wmtexe/cmi/api.py
+++ b/wmtexe/cmi/api.py
@@ -40,7 +40,7 @@ def is_valid_api_or_raise(api):
 def generate_compile_opts(flags, opt):
     assert(opt in ['--cflags', '--libs'])
 
-    if isinstance(flags, types.StringTypes):
+    if isinstance(flags, str):
         return flags
 
     try:
@@ -82,7 +82,7 @@ def execute_build(build):
     brew = build['brew']
     opts = brew.get('options', [])
 
-    if isinstance(opts, types.StringTypes):
+    if isinstance(opts, str):
         opts = [opts]
 
     system(['brew', 'install', brew['formula']] + opts)

--- a/wmtexe/cmi/bocca.py
+++ b/wmtexe/cmi/bocca.py
@@ -143,7 +143,7 @@ def replace_class_name(src, dest, include=None, prefix=None, cflags=None,
 
 
 def substitute_in_file(file_like, pattern, repl):
-    if isinstance(file_like, types.StringTypes):
+    if isinstance(file_like, str):
         with open(file_like, 'r') as fp:
             contents = fp.read()
     else:
@@ -163,7 +163,7 @@ def substitute_patterns(subs, string):
 
 
 def substitute_patterns_in_file(subs, file_like):
-    if isinstance(file_like, types.StringTypes):
+    if isinstance(file_like, str):
         with open(file_like, 'r') as fp:
             contents = fp.read()
     else:
@@ -315,7 +315,7 @@ _GRID_TYPE_FUNCTIONS = {
 }
 
 def get_grid_type_defines(grid_types):
-    if isinstance(grid_types, types.StringTypes):
+    if isinstance(grid_types, str):
         grid_types = [grid_types]
 
     defines = []
@@ -336,7 +336,7 @@ def create_bmi_class(name, bocca=None, language='c', bmi_mapping=None,
         bmi_mapping.setdefault('libs', pkg_config(pkg_config_package, '--libs'))
 
     bmi_mapping.setdefault('includes', '')
-    if not isinstance(bmi_mapping['includes'], types.StringTypes):
+    if not isinstance(bmi_mapping['includes'], str):
         bmi_mapping['includes'] = os.linesep.join(bmi_mapping['includes'])
 
     bmi_mapping.setdefault('prefix', '')

--- a/wmtexe/cmi/bocca.py
+++ b/wmtexe/cmi/bocca.py
@@ -1,4 +1,6 @@
 #! /usr/bin/env python
+from __future__ import print_function
+
 import os
 import subprocess
 import types
@@ -136,7 +138,7 @@ def replace_class_name(src, dest, include=None, prefix=None, cflags=None,
             elif line.startswith('LIBS ='):
                 line = ' '.join([line.rstrip(), libs])
 
-            print line.rstrip()
+            print(line.rstrip())
         f.close()
 
 

--- a/wmtexe/cmi/bocca.py
+++ b/wmtexe/cmi/bocca.py
@@ -345,7 +345,7 @@ def create_bmi_class(name, bocca=None, language='c', bmi_mapping=None,
     except KeyError:
         bmi_mapping['defines'] = ''
 
-    for key in bmi_mapping.keys():
+    for key in list(bmi_mapping.keys()):
         bmi_mapping['bmi_' + key] = bmi_mapping[key]
 
     with mktemp(prefix='csdms', suffix='.d') as destdir:

--- a/wmtexe/cmi/fetch.py
+++ b/wmtexe/cmi/fetch.py
@@ -58,7 +58,7 @@ def build_api(build):
     if isinstance(build, dict) and 'brew' in build:
         brew = build['brew']
         opts = brew.get('options', [])
-        if isinstance(opts, types.StringTypes):
+        if isinstance(opts, str):
             opts = [opts]
         system(['brew', 'install', brew['formula']] + opts)
     else:

--- a/wmtexe/cmi/fetch.py
+++ b/wmtexe/cmi/fetch.py
@@ -1,4 +1,6 @@
 #! /usr/bin/env python
+from __future__ import print_function
+
 import os
 import subprocess
 import re
@@ -107,7 +109,7 @@ def main():
 
         add_bmi_component(proj, bmi)
 
-    print yaml.dump(proj, default_flow_style=False)
+    print(yaml.dump(proj, default_flow_style=False))
 
 
 if __name__ == '__main__':

--- a/wmtexe/cmi/make.py
+++ b/wmtexe/cmi/make.py
@@ -1,5 +1,6 @@
-import argparse
+from __future__ import print_function
 
+import argparse
 import yaml
 
 from .bocca import make_project, ProjectExistsError
@@ -17,7 +18,7 @@ def main():
     try:
         make_project(yaml.load(args.file), clobber=args.clobber)
     except ProjectExistsError as error:
-        print 'The specified project (%s) already exists. Exiting.' % error
+        print('The specified project (%s) already exists. Exiting.' % error)
 
 
 if __name__ == '__main__':

--- a/wmtexe/cmi/utils.py
+++ b/wmtexe/cmi/utils.py
@@ -96,7 +96,7 @@ def which(prog, env=None):
 
 
 def pkg_config(name, opts):
-    if isinstance(opts, types.StringTypes):
+    if isinstance(opts, str):
         opts = [opts]
 
     try:

--- a/wmtexe/commands/configure.py
+++ b/wmtexe/commands/configure.py
@@ -44,7 +44,7 @@ class Configure(Command):
         pass
 
     def run(self):
-        import ConfigParser
+        import configparser
 
         from ..config import SiteConfiguration
 

--- a/wmtexe/commands/configure.py
+++ b/wmtexe/commands/configure.py
@@ -1,6 +1,6 @@
 """Configures a wmt-exe environment with setuptools."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 from setuptools import Command
 from distutils.spawn import find_executable
@@ -61,7 +61,7 @@ class Configure(Command):
         config.set('paths', 'exec_dir', self.exec_dir)
 
         if path.isfile('wmt.cfg') and not self.clobber:
-            print 'wmt.cfg: file exists (use --clobber to overwrite)'
+            print('wmt.cfg: file exists (use --clobber to overwrite)')
         else:
             config.write('wmt.cfg')
-            print 'configuration written to wmt.cfg'
+            print('configuration written to wmt.cfg')

--- a/wmtexe/commands/install.py
+++ b/wmtexe/commands/install.py
@@ -1,8 +1,9 @@
 """Installs wmt-exe with setuptools."""
 
+from __future__ import print_function
+
 from setuptools.command.install import install
 import os
-
 
 from .. import formatting
 
@@ -64,5 +65,5 @@ class Install(install):
 
         self.copy_file('wmt.cfg', wmt_cfg)
 
-        print formatting.bright(formatting.red(
-            _POST_INSTALL_MESSAGE.format(wmt_cfg=wmt_cfg)))
+        print(formatting.bright(formatting.red(
+            _POST_INSTALL_MESSAGE.format(wmt_cfg=wmt_cfg))))

--- a/wmtexe/config.py
+++ b/wmtexe/config.py
@@ -103,7 +103,7 @@ class SiteConfiguration(object):
             Name of configuration file.
 
         """
-        if isinstance(file, (str,)):
+        if isinstance(file, str):
             with open(file, 'w') as fp:
                 self.write(fp)
         else:

--- a/wmtexe/config.py
+++ b/wmtexe/config.py
@@ -38,7 +38,7 @@ _DEFAULTS = [
 class SiteConfiguration(object):
     """Configure a wmt-exe environment."""
     def __init__(self):
-        from ConfigParser import ConfigParser
+        from configparser import ConfigParser
 
         config = ConfigParser()
         for section, values in _DEFAULTS:
@@ -129,7 +129,7 @@ class SiteConfiguration(object):
         return conf
 
     def __str__(self):
-        from StringIO import StringIO
+        from io import StringIO
         output = StringIO()
         self._config.write(output)
 

--- a/wmtexe/config.py
+++ b/wmtexe/config.py
@@ -103,7 +103,7 @@ class SiteConfiguration(object):
             Name of configuration file.
 
         """
-        if isinstance(file, types.StringTypes):
+        if isinstance(file, (str,)):
             with open(file, 'w') as fp:
                 self.write(fp)
         else:

--- a/wmtexe/env.py
+++ b/wmtexe/env.py
@@ -1,5 +1,7 @@
 """Classes for configuring a wmt-exe environment."""
 
+from __future__ import print_function
+
 import sys
 from os import path, pathsep, linesep
 from collections import OrderedDict
@@ -88,7 +90,7 @@ class Babel(object):
             return subprocess.check_output(
                 [self.cca_spec_babel_config, '--var', var]).strip()
         except (OSError, subprocess.CalledProcessError):
-            print [self.cca_spec_babel_config, '--var', var]
+            print([self.cca_spec_babel_config, '--var', var])
             raise
             return None
 

--- a/wmtexe/env.py
+++ b/wmtexe/env.py
@@ -288,6 +288,6 @@ class WmtEnvironment(object):
 
     def __str__(self):
         lines = []
-        for item in self._env.items():
+        for item in list(self._env.items()):
             lines.append('export %s=%s' % item)
         return linesep.join(lines)

--- a/wmtexe/formatting.py
+++ b/wmtexe/formatting.py
@@ -26,7 +26,7 @@ _COLORS = [
 
 _CODES = {}
 
-for (_attr, _val) in _ATTRS.items():
+for (_attr, _val) in list(_ATTRS.items()):
     _CODES[_attr] = '\x1b[' + _val
 
 

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -59,7 +59,7 @@ class Launcher(object):
                 raise
         with open(self.script_path, 'w') as f:
             f.write(self.script(**kwds))
-        os.chmod(self.script_path, 0755)
+        os.chmod(self.script_path, 0o755)
 
     def after_launch(self, **kwds):
         """Perform actions after launching job.
@@ -272,7 +272,7 @@ sbatch --output={output_file} {script_path}
         Launcher.before_launch(self, **kwds)
         with open(self.run_script_path, 'w') as f:
             f.write(self.run_script(**kwds))
-        os.chmod(self.run_script_path, 0755)
+        os.chmod(self.run_script_path, 0o755)
 
     def run_script(self, **kwds):
         """Generate the run script that submits job to scheduler.

--- a/wmtexe/launcher.py
+++ b/wmtexe/launcher.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import subprocess
-from types import StringTypes
 
 
 class Launcher(object):
@@ -154,7 +153,7 @@ class Launcher(object):
             command += ['--server-url={}'.format(self.server_url)]
 
         if extra_args:
-            if isinstance(extra_args, StringTypes):
+            if isinstance(extra_args, str):
                 extra_args = shlex.split(extra_args)
             command += [quote(arg) for arg in extra_args]
 

--- a/wmtexe/task.py
+++ b/wmtexe/task.py
@@ -655,7 +655,7 @@ class RunTask(WmtTaskReporter):
 
     def run(self):
         """Run all components in simulation."""
-        for (component, path) in components_to_run(self.sim_dir).items():
+        for (component, path) in list(components_to_run(self.sim_dir).items()):
             self.report('running', 'running component: %s' % component)
             self.run_component(component, run_dir=path)
 
@@ -770,7 +770,7 @@ class RunTask(WmtTaskReporter):
 class RunComponentsSeparately(RunTask):
     """Task for running components individually."""
     def run(self):
-        for (component, path) in components_to_run(self.sim_dir).items():
+        for (component, path) in list(components_to_run(self.sim_dir).items()):
             self.report('running', 'running component: %s' % component)
             self.run_component(component, run_dir=path)
 


### PR DESCRIPTION
In this PR, I've used the `2to3` script to translate the wmt-exe code to Python 3, while attempting to maintain backward compatibility with Python 2.7. I ran the `2to3` filters singly or in small groups and performed spot checks to make sure that the changes didn't bork the code.

With these changes, wmt-exe can be installed into a Python 3.6 distribution.